### PR TITLE
Create includedir_server directory when installing headers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,4 +38,5 @@ maintainer-clean:
 install: installincludes
 
 installincludes:
+	$(INSTALL) -d '$(DESTDIR)$(includedir_server)/'
 	$(INSTALL_DATA) $(addprefix $(srcdir)/, $(INCLUDES)) '$(DESTDIR)$(includedir_server)/'


### PR DESCRIPTION
When using DESTDIR, the target directory is likely not yet existent,
create it from the installincludes rule.