### PR TITLE
PGPRO-5414: Windows build fix for Postgres Pro Standard 15

### DIFF
--- a/jsquery_gram.y
+++ b/jsquery_gram.y
@@ -47,7 +47,7 @@ typedef struct string {
 	int		len;
 	int		total;
 } string;
-#include <jsquery_gram.h>
+#include "jsquery_gram.h"
 
 /* flex 2.5.4 doesn't bother with a decl for this */
 int jsquery_yylex(YYSTYPE * yylval_param);


### PR DESCRIPTION
In PostgreSQL 15 the variables contrib_extraincludes and contrib_extrasource
from src/tools/msvc/Mkvcbuild.pm are no longer used. With this change the
contrib module jsquery does not need them either.