### PR TITLE
PGPRO-6864: do not use the function pg_atoi if possible

### DIFF
--- a/jsquery_gram.y
+++ b/jsquery_gram.y
@@ -71,7 +71,11 @@ makeIndexArray(string *s)
 {
 	JsQueryParseItem* v = makeItemType(jqiIndexArray);
 
+#if PG_VERSION_NUM >= 120000
+	v->arrayIndex = pg_strtoint32(s->val);
+#else
 	v->arrayIndex = pg_atoi(s->val, 4, 0);
+#endif
 
 	return v;
 }


### PR DESCRIPTION
In PostgreSQL version 12 or higher it's more effecient to use the function
pg_strtoint32 instead (see the commit 86eaf208ea048936df6be77276a246d3f92e9620).
And in PostgreSQL 15 the function pg_atoi was removed altogether (see the commit
73508475d69e90f98ebd9b7e1a5933a26a49c5e9). Therefore if possible use the
function pg_strtoint32 instead.