### PR TITLE
Fix build due to new checks in PostgreSQL 16

### DIFF
--- a/jsquery.h
+++ b/jsquery.h
@@ -26,7 +26,7 @@ typedef struct
 	int32	vl_len_;	/* varlena header (do not touch directly!) */
 } JsQuery;
 
-#define DatumGetJsQueryP(d)	((JsQuery*)DatumGetPointer(PG_DETOAST_DATUM(d)))
+#define DatumGetJsQueryP(d)	((JsQuery*) PG_DETOAST_DATUM(d))
 #define PG_GETARG_JSQUERY(x)	DatumGetJsQueryP(PG_GETARG_DATUM(x))
 #define PG_RETURN_JSQUERY(p)	PG_RETURN_POINTER(p)
 


### PR DESCRIPTION
The macro PG_DETOAST_DATUM returns a pointer to a varlena structure and the input to the function DatumGetPointer must be of type Datum (see the commit c8b2ef05f481ef06326d7b9f3eb14b303f215c7e in PostgreSQL 16). So use a simple cast instead of the function DatumGetPointer.