### PR TITLE
[PGPRO-9047] Fixed parsing empty string into NULL

### DIFF
--- a/expected/jsquery.out
+++ b/expected/jsquery.out
@@ -3,6 +3,11 @@ set escape_string_warning=off;
 set standard_conforming_strings=on;
 CREATE TABLE test_jsquery (v jsonb);
 \copy test_jsquery from 'data/test_jsquery.data'
+select ''::jsquery;
+ERROR:  bad jsquery representation
+LINE 1: select ''::jsquery;
+               ^
+DETAIL:  No symbols read at the end of input
 select 'asd.zzz = 13'::jsquery;
      jsquery      
 ------------------

--- a/expected/jsquery_1.out
+++ b/expected/jsquery_1.out
@@ -3,6 +3,11 @@ set escape_string_warning=off;
 set standard_conforming_strings=on;
 CREATE TABLE test_jsquery (v jsonb);
 \copy test_jsquery from 'data/test_jsquery.data'
+select ''::jsquery;
+ERROR:  bad jsquery representation
+LINE 1: select ''::jsquery;
+               ^
+DETAIL:  No symbols read at the end of input
 select 'asd.zzz = 13'::jsquery;
      jsquery      
 ------------------

--- a/jsquery_gram.y
+++ b/jsquery_gram.y
@@ -258,7 +258,9 @@ result:
 										*result = $1;
 										(void) yynerrs;		/* suppress compiler warning */
 									}
-	| /* EMPTY */					{ *result = NULL; }
+	| /* EMPTY */					{
+										*result = NULL;
+										yyerror(NULL, "No symbols read"); }
 	;
 
 array:

--- a/jsquery_io.c
+++ b/jsquery_io.c
@@ -162,17 +162,12 @@ jsquery_in(PG_FUNCTION_ARGS)
 
 	appendStringInfoSpaces(&buf, VARHDRSZ);
 
-	if (jsquery != NULL)
-	{
-		flattenJsQueryParseItem(&buf, jsquery, false);
+	flattenJsQueryParseItem(&buf, jsquery, false);
 
-		res = (JsQuery*)buf.data;
-		SET_VARSIZE(res, buf.len);
+	res = (JsQuery*)buf.data;
+	SET_VARSIZE(res, buf.len);
 
-		PG_RETURN_JSQUERY(res);
-	}
-
-	PG_RETURN_NULL();
+	PG_RETURN_JSQUERY(res);
 }
 
 static void

--- a/jsquery_scan.l
+++ b/jsquery_scan.l
@@ -206,7 +206,7 @@ yyerror(JsQueryParseItem **result, const char *message)
 				(errcode(ERRCODE_SYNTAX_ERROR),
 				 errmsg("bad jsquery representation"),
 				 /* translator: %s is typically "syntax error" */
-				 errdetail("%s at end of input", message)));
+				 errdetail("%s at the end of input", message)));
 	}
 	else
 	{

--- a/sql/jsquery.sql
+++ b/sql/jsquery.sql
@@ -7,6 +7,7 @@ CREATE TABLE test_jsquery (v jsonb);
 
 \copy test_jsquery from 'data/test_jsquery.data'
 
+select ''::jsquery;
 select 'asd.zzz = 13'::jsquery;
 select 'asd.zzz < 13'::jsquery;
 select 'asd(zzz < 13)'::jsquery;


### PR DESCRIPTION
Empty string is not a correct jsquery, also input functions should return result of datatype which is being parsed.

Tags: jsquery